### PR TITLE
Use workspace variables wherever possible

### DIFF
--- a/i3/config
+++ b/i3/config
@@ -99,32 +99,41 @@ bindsym $mod+a focus parent
 bindsym $mod+Tab workspace back_and_forth
 
 set $workspace01 "1"
+set $workspace02 "2"
+set $workspace03 "3"
+set $workspace04 "4"
+set $workspace05 "5"
+set $workspace06 "6"
+set $workspace07 "7"
+set $workspace08 "8"
+set $workspace09 "9"
+set $workspace10 "10"
 
 workspace $workspace01 output DVI-0
 
 # switch to workspace
 bindsym $mod+1 workspace $workspace01
-bindsym $mod+2 workspace 2
-bindsym $mod+3 workspace 3
-bindsym $mod+4 workspace 4
-bindsym $mod+5 workspace 5
-bindsym $mod+6 workspace 6
-bindsym $mod+7 workspace 7
-bindsym $mod+8 workspace 8
-bindsym $mod+9 workspace 9
-bindsym $mod+0 workspace 10
+bindsym $mod+2 workspace $workspace02
+bindsym $mod+3 workspace $workspace03
+bindsym $mod+4 workspace $workspace04
+bindsym $mod+5 workspace $workspace05
+bindsym $mod+6 workspace $workspace06
+bindsym $mod+7 workspace $workspace07
+bindsym $mod+8 workspace $workspace08
+bindsym $mod+9 workspace $workspace09
+bindsym $mod+0 workspace $workspace10
 
 # move focused container to workspace
-bindsym $mod+Shift+1 move container to workspace 1
-bindsym $mod+Shift+2 move container to workspace 2
-bindsym $mod+Shift+3 move container to workspace 3
-bindsym $mod+Shift+4 move container to workspace 4
-bindsym $mod+Shift+5 move container to workspace 5
-bindsym $mod+Shift+6 move container to workspace 6
-bindsym $mod+Shift+7 move container to workspace 7
-bindsym $mod+Shift+8 move container to workspace 8
-bindsym $mod+Shift+9 move container to workspace 9
-bindsym $mod+Shift+0 move container to workspace 10
+bindsym $mod+Shift+1 move container to workspace $workspace01
+bindsym $mod+Shift+2 move container to workspace $workspace02
+bindsym $mod+Shift+3 move container to workspace $workspace03
+bindsym $mod+Shift+4 move container to workspace $workspace04
+bindsym $mod+Shift+5 move container to workspace $workspace05
+bindsym $mod+Shift+6 move container to workspace $workspace06
+bindsym $mod+Shift+7 move container to workspace $workspace07
+bindsym $mod+Shift+8 move container to workspace $workspace08
+bindsym $mod+Shift+9 move container to workspace $workspace09
+bindsym $mod+Shift+0 move container to workspace $workspace10
 
 # reload the configuration file
 bindsym $mod+Shift+c reload


### PR DESCRIPTION
This allows you to change a workspace name by only changing one variable.

Prevents you from forgetting to change something whenever you change a workspace name (like you accidentally have with workspace 1 and moving windows)